### PR TITLE
Add support forward req headers

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,3 +8,5 @@ BLOCKED_PUBKEYS=
 WHITELISTED_PUBKEYS=
 # Set true to filter proxy events
 FILTER_PROXY_EVENTS=
+# Set true to enable forwarding of request headers to upstream server
+ENABLE_FORWARD_REQ_HEADERS=false

--- a/filter.ts
+++ b/filter.ts
@@ -74,6 +74,8 @@ const whitelistedPubkeys: string[] =
     : [];
 // Filter proxy events
 const filterProxyEvents = process.env.FILTER_PROXY_EVENTS === "true";
+// Forward request headers to upstream
+const enableForwardReqHeaders = process.env.ENABLE_FORWARD_REQ_HEADERS === "true";
 
 // クライアントIPアドレスのCIDRフィルタ
 const cidrRanges: string[] = [
@@ -222,8 +224,12 @@ function listen(): void {
       // ソケットごとにユニークなIDを付与
       const socketId = uuidv4();
 
+      // Check whether we want to forward original request headers to the upstream server
+      // This will be useful if the upstream server need original request headers to do operations like rate-limiting, etc.
+      let wsClientOptions = enableForwardReqHeaders ? { headers: req.headers } : undefined;
+
       // 上流となるリレーサーバーと接続
-      let upstreamSocket = new WebSocket(upstreamWsUrl);
+      let upstreamSocket = new WebSocket(upstreamWsUrl, wsClientOptions);
       connectUpstream(upstreamSocket, downstreamSocket);
 
       // クライアントとの接続が確立したら、アイドルタイムアウトを設定


### PR DESCRIPTION
imksoo-san (Minato-san), this PR will add feature to add support for forwarding req headers (optional feature, default is false). This can be useful for upstream/backend relay if upstream relay want to use req headers value for rate-limiting or other functions.

Example:
strfry has its own rate-limiting mechanism, if we don't forward request headers it will assume our localhost is the one who makes a lot of request.

Thank you.