### PR TITLE
Max websocket payload setting support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,6 +10,8 @@ WHITELISTED_PUBKEYS=
 FILTER_PROXY_EVENTS=
 # Set true to enable forwarding of request headers to upstream server
 ENABLE_FORWARD_REQ_HEADERS=false
+# Set maximum websocket server payload size (maximum allowed message size) in bytes
+MAX_WEBSOCKET_PAYLOAD_SIZE=1000000
 
 # Regular expressions for content filtering. Each regular expression is stored as a separate environment variable.
 # These regular expressions are used to match specific patterns in texts.

--- a/filter.ts
+++ b/filter.ts
@@ -59,6 +59,8 @@ const whitelistedPubkeys: string[] =
 const filterProxyEvents = process.env.FILTER_PROXY_EVENTS === "true";
 // Forward request headers to upstream
 const enableForwardReqHeaders = process.env.ENABLE_FORWARD_REQ_HEADERS === "true";
+// Set maximum websocket server payload size (maximum allowed message size) in bytes
+const maxWebsocketPayloadSize: number = parseInt(process.env.MAX_WEBSOCKET_PAYLOAD_SIZE ?? "1000000");
 
 // クライアントIPアドレスのCIDRフィルタ
 const cidrRanges: string[] = Object.keys(process.env)
@@ -194,7 +196,7 @@ function listen(): void {
     },
   );
   // WebSocketサーバーの構成
-  const wss = new WebSocket.Server({ server });
+  const wss = new WebSocket.Server({ server: server, maxPayload: maxWebsocketPayloadSize });
   wss.on(
     "connection",
     async (downstreamSocket: WebSocket, req: http.IncomingMessage) => {


### PR DESCRIPTION
Kirino-san,

This PR gives basic support for maximum websocket payload setting with default to 1MB. I have noticed that the default setting of ws library has been set to [100MiB](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback). It was quite risky (DoS risk) for nostr relay to accept big payload size.

Simple test case:
```javascript
let relay = new WebSocket(relayUrl);
relay.on("open", async () => {
    const kindList = (()=>{
        let counter = 0;
        let result = [];
        let limit = 10000000;
        // limit = 1000;
        while (counter < limit) {
            result.push(counter);
            counter += 1;
        }
        return result;
    })();
    const message: any[] = ["REQ", "subid", { kinds: kindList, limit: 1 }];
    const message2 = kindList.join("");
    relay.send(JSON.stringify(message));
    relay.send(message2);
});
```

nostr-filter will reject and give proper error for big payload message:
```
{"msg":"DOWNSTREAM ERROR","ip":"::1","port":0,"socketId":"3231018c-63e4-4d4e-aa46-e4d09c13486a","connectionCountForIP":1,"error":{"code":"WS_ERR_UNSUPPORTED_MESSAGE_LENGTH"}}
```

What do you think?

Thank you.