### PR TITLE
Use UUID v7 for socket IDs and bump uuid dependency

### DIFF
--- a/filter.ts
+++ b/filter.ts
@@ -5,7 +5,7 @@ import path from "path";
 import url from "url";
 import * as net from "net";
 import { Mutex } from "async-mutex";
-import { v4 as uuidv4 } from "uuid";
+import { v7 as uuidv7 } from "uuid";
 import * as mime from "mime-types";
 import dotenv from "dotenv";
 
@@ -212,7 +212,7 @@ function listen(): void {
       const subscriptionSizeMutex = new Mutex();
 
       // ソケットごとにユニークなIDを付与
-      const socketId = uuidv4();
+      const socketId = uuidv7();
 
       // Check whether we want to forward original request headers to the upstream server
       // This will be useful if the upstream server need original request headers to do operations like rate-limiting, etc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT License",
       "dependencies": {
         "@types/mime-types": "^2.1.1",
-        "@types/uuid": "^9.0.1",
+        "@types/uuid": "^11.0.0",
         "@types/ws": "^8.5.4",
         "async-mutex": "^0.4.0",
         "dotenv": "^16.3.1",
         "mime-types": "^2.1.35",
         "typescript": "^5.0.2",
-        "uuid": "^9.0.0",
+        "uuid": "^11.1.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -96,9 +96,14 @@
       "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw=="
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
+      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
+      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "*"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -255,11 +260,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   "license": "MIT License",
   "dependencies": {
     "@types/mime-types": "^2.1.1",
-    "@types/uuid": "^9.0.1",
+    "@types/uuid": "^11.0.0",
     "@types/ws": "^8.5.4",
     "async-mutex": "^0.4.0",
     "dotenv": "^16.3.1",
     "mime-types": "^2.1.35",
     "typescript": "^5.0.2",
-    "uuid": "^9.0.0",
+    "uuid": "^11.1.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation
- Use time-ordered UUIDs for socket identifiers by switching from `v4` to `v7` to improve ordering and uniqueness semantics.
- `socketId` is used in logs and map keys, so keep a compatible hyphenated string format while gaining timestamp ordering.
- `v7` is not available in the current `uuid` version, so the dependency and types must be upgraded to expose `v7`.
- Verify the codebase still type-checks and builds after the API and dependency changes.

### Description
- Replaced `import { v4 as uuidv4 } from "uuid";` with `import { v7 as uuidv7 } from "uuid";` and changed `const socketId = uuidv4();` to `const socketId = uuidv7();` in `filter.ts`.
- Bumped `uuid` to `^11.1.0` and `@types/uuid` to `^11.0.0` in `package.json` and updated `package-lock.json` accordingly.
- Ran `npm install` to refresh `node_modules` and lockfile so `v7` is available at runtime.

### Testing
- Ran `npm install` to update dependencies and the command completed successfully. (succeeded)
- Ran TypeScript compilation with `npm exec tsc --noEmit` after the upgrade and it completed without errors. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d15766cac8331abd1d30dc7d74a0a)